### PR TITLE
Fix parsing of kindle highlights page

### DIFF
--- a/lib/kindle_manager/parsers/highlights_parser.rb
+++ b/lib/kindle_manager/parsers/highlights_parser.rb
@@ -21,7 +21,7 @@ module KindleManager
       end
 
       def author
-        @_author ||= @node.css('h1.kp-notebook-metadata').first.text
+        @_author ||= @node.css('p.kp-notebook-metadata.a-size-base').first.text
       end
 
       def last_annotated_on
@@ -61,7 +61,7 @@ module KindleManager
       # This can be used to verify the count of hightlights and notes
       def count_summary
         @_count_summary ||= begin
-          text = @node.css('h1.kp-notebook-metadata').last.text.strip
+          text = @node.css('.kp-notebook-row-separator > .kp-notebook-metadata').last.text.strip
           a, b = text.split('|').map{|text| m = text.match(/\d+/); m.nil? ? nil : m[0].to_i }
           {'text' => text, 'highlights_count' => a, 'notes_count' => b}
         end

--- a/spec/fixtures/files/test_highlights.html
+++ b/spec/fixtures/files/test_highlights.html
@@ -1,31 +1,33 @@
 <!DOCTYPE html>
-<!-- Copyright (c) 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved. --><html xmlns="http://www.w3.org/1999/xhtml" class="a-js a-audio a-video a-canvas a-svg a-drag-drop a-geolocation a-history a-webworker a-autofocus a-input-placeholder a-textarea-placeholder a-local-storage a-gradients a-hires a-transform3d a-touch-scrolling a-text-shadow a-text-stroke a-box-shadow a-border-radius a-border-image a-opacity a-transform a-transition a-audio a-video a-canvas a-svg a-drag-drop a-geolocation a-history a-webworker a-autofocus a-input-placeholder a-textarea-placeholder a-local-storage a-gradients a-hires a-transform3d a-touch-scrolling a-text-shadow a-text-stroke a-box-shadow a-border-radius a-border-image a-opacity a-transform a-transition" data-19ax5a9jf="dingo" data-aui-build-date="3.17.3.2-2017-03-07" lang="en">
+<!-- Copyright (c) 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved. --><html xmlns="http://www.w3.org/1999/xhtml" class=" a-js a-audio a-video a-canvas a-svg a-drag-drop a-geolocation a-history a-webworker a-autofocus a-input-placeholder a-textarea-placeholder a-local-storage a-gradients a-hires a-transform3d a-touch-scrolling a-text-shadow a-text-stroke a-box-shadow a-border-radius a-border-image a-opacity a-transform a-transition" data-19ax5a9jf="dingo" data-aui-build-date="3.17.3.2-2017-03-07" lang="ja">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <title>Kindle: Your Notes and Highlights</title>
+    <title>Kindle: メモとハイライト</title>
   </head>
-  <body class="a-aui_51744-c a-aui_57326-c a-aui_58736-t1 a-aui_72554-c a-aui_83815-c a-aui_86171-c a-aui_96511-t1 a-aui_accessibility_49860-c a-aui_attr_validations_1_51371-c a-aui_bolt_62845-c a-aui_noopener_84118-t1 a-aui_ux_59374-c a-aui_ux_60000-c a-aui_ux_92006-c a-dex_92889-c a-meter-animate">
+  <body class="a-aui_51744-c a-aui_57326-c a-aui_58736-t1 a-aui_72554-c a-aui_83815-c a-aui_86171-c a-aui_96511-c a-aui_accessibility_49860-c a-aui_attr_validations_1_51371-c a-aui_bolt_62845-c a-aui_noopener_84118-t1 a-aui_ux_59374-c a-aui_ux_60000-c a-aui_ux_92006-c a-dex_92889-c a-meter-animate">
     <div id="a-page">
-      <div id="kp-notebook-spinner" class="kp-spinner" title="0" style="display: none;"></div>
+      <div id="kp-notebook-spinner" class="kp-spinner" title="0"></div>
       <div id="kp-notebook-head" class="a-container kp-notebook-row-separator">
         <div class="a-row">
           <div class="a-column a-span3 a-spacing-top-mini"><img alt="Kindle" src="img/Kindle_Logo_RGB.png" height="30"></div>
-          <div class="a-column a-span6 a-spacing-top-mini kp-notebook-header"><span class="a-size-large a-color-base kp-notebook-title">Your Notes and Highlights</span></div>
-          <div class="a-column a-span3 a-text-right a-spacing-top-mini a-span-last"><span class="a-declarative" data-action="a-popover" data-a-popover='{"closeButton":"false","name":"userPopover","position":"triggerBottom"}'><a class="a-popover-trigger a-declarative"><span class="a-size-small a-color-base">Hello,<span class="a-letter-space"></span></span><span class="a-size-small a-color-link kp-notebook-username">Kazuho</span><span class="a-size-small a-color-link"> </span><i class="a-icon a-icon-popover"></i></a>
+          <div class="a-column a-span6 a-spacing-top-mini kp-notebook-header">
+            <h1 class="a-size-large a-color-base kp-notebook-title">メモとハイライト</h1>
+          </div>
+          <div class="a-column a-span3 a-text-right a-spacing-top-mini a-span-last"><span class="a-declarative" data-action="a-popover" data-a-popover='{"closeButton":"false","name":"userPopover","position":"triggerBottom"}'><a class="a-popover-trigger a-declarative"><span class="a-size-small a-color-base"> <span class="a-letter-space"></span></span><span class="a-size-small a-color-link kp-notebook-username">Kazuho</span><span class="a-size-small a-color-link">さん</span><i class="a-icon a-icon-popover"></i></a>
               <div class="a-popover-preload" id="a-popover-userPopover">
                 <table class="a-normal">
                   <tbody>
                     <tr>
-                      <td><a class="a-link-normal" target="_blank" rel="noopener" href="https://www.amazon.com/gp/help/customer/display.html?nodeId=201796890&amp;ref_=k4w_nb_ln">Legal Notices</a></td>
+                      <td><a class="a-link-normal" target="_blank" rel="noopener" href="https://www.amazon.com/gp/help/customer/display.html?nodeId=201796890&amp;ref_=k4w_nb_ln">法的通知</a></td>
                     </tr>
                     <tr>
-                      <td><a class="a-link-normal" target="_blank" rel="noopener" href="https://www.amazon.com/gp/help/customer/display.html?nodeId=468496&amp;ref_=k4w_nb_pn">Privacy Notice</a></td>
+                      <td><a class="a-link-normal" target="_blank" rel="noopener" href="https://www.amazon.com/gp/help/customer/display.html?nodeId=468496&amp;ref_=k4w_nb_pn">プライバシー規約</a></td>
                     </tr>
                     <tr>
-                      <td><a class="a-link-normal" href="mailto:notes-and-highlights-feedback@amazon.com">Feedback</a></td>
+                      <td><a class="a-link-normal" href="mailto:notes-and-highlights-feedback@amazon.com">フィードバックの送信</a></td>
                     </tr>
                     <tr>
-                      <td><a class="a-link-normal" href="https://read.amazon.com/kp/logout?amazonDeviceType=A2CLFWBIMVSE9N&amp;purpose=NOTEBOOK&amp;appName=notebook">Sign Out</a></td>
+                      <td><a class="a-link-normal" href="https://read.amazon.com/kp/logout?amazonDeviceType=A2CLFWBIMVSE9N&amp;purpose=NOTEBOOK&amp;appName=notebook">サインアウト</a></td>
                     </tr>
                   </tbody>
                 </table>
@@ -37,10 +39,10 @@
         <div class="a-fixed-left-grid-inner" style="padding-left: 300px;">
           <div id="library" class="a-color-alternate-background a-fixed-left-grid-col kp-notebook-library-annotation-separator a-col-left">
             <div id="books-filter" class="a-row a-spacing-base a-spacing-top-base kp-notebook-books-filter">
-              <h6 class="a-color-base a-text-center a-text-bold">Annotated books from your library</h6>
-              <div class="a-row kp-notebook-header"><span class="a-size-small a-color-base">(Most recently updated shown first)</span></div>
+              <p class="a-spacing-none a-text-center a-size-mini a-color-base a-text-bold a-text-caps">ライブラリ内の注釈付きの本</p>
+              <div class="a-row kp-notebook-header"><span class="a-size-small a-color-base">(最近更新した順に表示されます)</span></div>
             </div>
-            <div id="library-section" class="a-section kp-notebook-library-header-separator" style="margin-bottom: 0px; height: 486px;">
+            <div id="library-section" class="a-section kp-notebook-library-header-separator" style="margin-bottom: 0px; height: 487px;">
               <div class="a-scroller kp-notebook-scroller-addon a-scroller-vertical">
                 <div id="kp-notebook-library" class="a-row">
                   <div id="B004YW6M6G" class="a-row kp-notebook-library-each-book a-color-base-background">
@@ -48,108 +50,108 @@
                         <div class="a-row">
                           <div class="a-column a-span4 a-push4 a-spacing-medium a-spacing-top-medium"><img src="https://images-na.ssl-images-amazon.com/images/I/51inXHEQAJL._SY160.jpg" class="kp-notebook-cover-image kp-notebook-cover-image-border"></div>
                         </div>
-                        <h1 class="a-size-base a-color-base a-text-center a-text-bold">Design Patterns in Ruby (Adobe Reader) (Addison-Wesley Professional Ruby Series)</h1>
-                        <h1 class="a-size-base a-spacing-base a-spacing-top-mini a-color-secondary a-text-center">By: Russ Olsen</h1>
-                      </a></span><input type="hidden" value="Wednesday June 21, 2017" id="kp-notebook-annotated-date-B004YW6M6G">
+                        <h2 class="a-size-base a-color-base a-text-center a-text-bold">Design Patterns in Ruby (Adobe Reader) (Addison-Wesley Professional Ruby Series)</h2>
+                        <p class="a-spacing-base a-spacing-top-mini a-text-center a-size-base a-color-secondary">著者: Russ Olsen</p>
+                      </a></span><input type="hidden" value="水曜日 6月 21, 2017" id="kp-notebook-annotated-date-B004YW6M6G">
                   </div>
                   <div id="B01FFXBKKU" class="a-row kp-notebook-library-each-book">
                     <span class="a-declarative" data-action="get-annotations-for-asin" data-get-annotations-for-asin='{"asin":"B01FFXBKKU"}'><a class="a-link-normal a-text-normal">
                         <div class="a-row">
                           <div class="a-column a-span4 a-push4 a-spacing-medium a-spacing-top-medium"><img src="https://images-na.ssl-images-amazon.com/images/I/81rajzvoEyL._SY160.jpg" class="kp-notebook-cover-image kp-notebook-cover-image-border"></div>
                         </div>
-                        <h1 class="a-size-base a-color-base a-text-center a-text-bold">Ruby: Learn Ruby in 24 Hours or Less - A Beginner’s Guide To Learning Ruby Programming Now (Ruby, Ruby Programming, Ruby Course)</h1>
-                        <h1 class="a-size-base a-spacing-base a-spacing-top-mini a-color-secondary a-text-center">By: Robert Dwight and Ruby</h1>
-                      </a></span><input type="hidden" value="Tuesday June 20, 2017" id="kp-notebook-annotated-date-B01FFXBKKU">
+                        <h2 class="a-size-base a-color-base a-text-center a-text-bold">Ruby: Learn Ruby in 24 Hours or Less - A Beginner’s Guide To Learning Ruby Programming Now (Ruby, Ruby Programming, Ruby Course)</h2>
+                        <p class="a-spacing-base a-spacing-top-mini a-text-center a-size-base a-color-secondary">著者: Robert Dwight、Ruby</p>
+                      </a></span><input type="hidden" value="火曜日 6月 20, 2017" id="kp-notebook-annotated-date-B01FFXBKKU">
                   </div>
                   <div id="B005EI84QA" class="a-row kp-notebook-library-each-book">
                     <span class="a-declarative" data-action="get-annotations-for-asin" data-get-annotations-for-asin='{"asin":"B005EI84QA"}'><a class="a-link-normal a-text-normal">
                         <div class="a-row">
                           <div class="a-column a-span4 a-push4 a-spacing-medium a-spacing-top-medium"><img src="https://images-na.ssl-images-amazon.com/images/I/81aISOpeDtL._SY160.jpg" class="kp-notebook-cover-image kp-notebook-cover-image-border"></div>
                         </div>
-                        <h1 class="a-size-base a-color-base a-text-center a-text-bold">The Book of Ruby: A Hands-On Guide for the Adventurous</h1>
-                        <h1 class="a-size-base a-spacing-base a-spacing-top-mini a-color-secondary a-text-center">By: Huw Collingbourne</h1>
-                      </a></span><input type="hidden" value="Tuesday June 20, 2017" id="kp-notebook-annotated-date-B005EI84QA">
+                        <h2 class="a-size-base a-color-base a-text-center a-text-bold">The Book of Ruby: A Hands-On Guide for the Adventurous</h2>
+                        <p class="a-spacing-base a-spacing-top-mini a-text-center a-size-base a-color-secondary">著者: Huw Collingbourne</p>
+                      </a></span><input type="hidden" value="火曜日 6月 20, 2017" id="kp-notebook-annotated-date-B005EI84QA">
                   </div>
                   <div id="B01A7R4HGI" class="a-row kp-notebook-library-each-book">
                     <span class="a-declarative" data-action="get-annotations-for-asin" data-get-annotations-for-asin='{"asin":"B01A7R4HGI"}'><a class="a-link-normal a-text-normal">
                         <div class="a-row">
                           <div class="a-column a-span4 a-push4 a-spacing-medium a-spacing-top-medium"><img src="https://images-na.ssl-images-amazon.com/images/I/81efcujiaZL._SY160.jpg" class="kp-notebook-cover-image kp-notebook-cover-image-border"></div>
                         </div>
-                        <h1 class="a-size-base a-color-base a-text-center a-text-bold">Ruby Performance Optimization: Why Ruby is Slow, and How to Fix It</h1>
-                        <h1 class="a-size-base a-spacing-base a-spacing-top-mini a-color-secondary a-text-center">By: Alexander Dymo</h1>
-                      </a></span><input type="hidden" value="Tuesday June 20, 2017" id="kp-notebook-annotated-date-B01A7R4HGI">
+                        <h2 class="a-size-base a-color-base a-text-center a-text-bold">Ruby Performance Optimization: Why Ruby is Slow, and How to Fix It</h2>
+                        <p class="a-spacing-base a-spacing-top-mini a-text-center a-size-base a-color-secondary">著者: Alexander Dymo</p>
+                      </a></span><input type="hidden" value="火曜日 6月 20, 2017" id="kp-notebook-annotated-date-B01A7R4HGI">
                   </div>
                   <div id="B01LYPZYJ4" class="a-row kp-notebook-library-each-book">
                     <span class="a-declarative" data-action="get-annotations-for-asin" data-get-annotations-for-asin='{"asin":"B01LYPZYJ4"}'><a class="a-link-normal a-text-normal">
                         <div class="a-row">
                           <div class="a-column a-span4 a-push4 a-spacing-medium a-spacing-top-medium"><img src="https://images-na.ssl-images-amazon.com/images/I/61XeQhgGqVL._SY160.jpg" class="kp-notebook-cover-image kp-notebook-cover-image-border"></div>
                         </div>
-                        <h1 class="a-size-base a-color-base a-text-center a-text-bold">Agile Web Development with Rails, 3rd Edition</h1>
-                        <h1 class="a-size-base a-spacing-base a-spacing-top-mini a-color-secondary a-text-center">By: Sam Ruby, Dave Thomas, and David Heinemeier Hansson</h1>
-                      </a></span><input type="hidden" value="Tuesday June 20, 2017" id="kp-notebook-annotated-date-B01LYPZYJ4">
+                        <h2 class="a-size-base a-color-base a-text-center a-text-bold">Agile Web Development with Rails, 3rd Edition</h2>
+                        <p class="a-spacing-base a-spacing-top-mini a-text-center a-size-base a-color-secondary">著者: Sam Ruby、Dave Thomas、David Heinemeier Hansson</p>
+                      </a></span><input type="hidden" value="火曜日 6月 20, 2017" id="kp-notebook-annotated-date-B01LYPZYJ4">
                   </div>
                   <div id="B004OVF09M" class="a-row kp-notebook-library-each-book">
                     <span class="a-declarative" data-action="get-annotations-for-asin" data-get-annotations-for-asin='{"asin":"B004OVF09M"}'><a class="a-link-normal a-text-normal">
                         <div class="a-row">
                           <div class="a-column a-span4 a-push4 a-spacing-medium a-spacing-top-medium"><img src="https://images-na.ssl-images-amazon.com/images/I/615q8pDH4wL._SY160.jpg" class="kp-notebook-cover-image kp-notebook-cover-image-border"></div>
                         </div>
-                        <h1 class="a-size-base a-color-base a-text-center a-text-bold">Rework: Business  - intelligent &amp; einfach (German Edition)</h1>
-                        <h1 class="a-size-base a-spacing-base a-spacing-top-mini a-color-secondary a-text-center">By: Jason Fried, David Heinemeier Hansson, and Heike Schlatterer</h1>
-                      </a></span><input type="hidden" value="Tuesday June 20, 2017" id="kp-notebook-annotated-date-B004OVF09M">
+                        <h2 class="a-size-base a-color-base a-text-center a-text-bold">Rework: Business  - intelligent &amp; einfach (German Edition)</h2>
+                        <p class="a-spacing-base a-spacing-top-mini a-text-center a-size-base a-color-secondary">著者: Jason Fried、David Heinemeier Hansson、Heike Schlatterer</p>
+                      </a></span><input type="hidden" value="火曜日 6月 20, 2017" id="kp-notebook-annotated-date-B004OVF09M">
                   </div>
                   <div id="B002MUAJ2A" class="a-row kp-notebook-library-each-book">
                     <span class="a-declarative" data-action="get-annotations-for-asin" data-get-annotations-for-asin='{"asin":"B002MUAJ2A"}'><a class="a-link-normal a-text-normal">
                         <div class="a-row">
                           <div class="a-column a-span4 a-push4 a-spacing-medium a-spacing-top-medium"><img src="https://images-na.ssl-images-amazon.com/images/I/411qjEq-jCL._SY160.jpg" class="kp-notebook-cover-image kp-notebook-cover-image-border"></div>
                         </div>
-                        <h1 class="a-size-base a-color-base a-text-center a-text-bold">Rework</h1>
-                        <h1 class="a-size-base a-spacing-base a-spacing-top-mini a-color-secondary a-text-center">By: Jason Fried and David Heinemeier Hansson</h1>
-                      </a></span><input type="hidden" value="Tuesday June 20, 2017" id="kp-notebook-annotated-date-B002MUAJ2A">
+                        <h2 class="a-size-base a-color-base a-text-center a-text-bold">Rework</h2>
+                        <p class="a-spacing-base a-spacing-top-mini a-text-center a-size-base a-color-secondary">著者: Jason Fried、David Heinemeier Hansson</p>
+                      </a></span><input type="hidden" value="火曜日 6月 20, 2017" id="kp-notebook-annotated-date-B002MUAJ2A">
                   </div>
                   <div id="B004EYT2FC" class="a-row kp-notebook-library-each-book">
                     <span class="a-declarative" data-action="get-annotations-for-asin" data-get-annotations-for-asin='{"asin":"B004EYT2FC"}'><a class="a-link-normal a-text-normal">
                         <div class="a-row">
                           <div class="a-column a-span4 a-push4 a-spacing-medium a-spacing-top-medium"><img src="https://images-na.ssl-images-amazon.com/images/I/81zblRAPS3L._SY160.jpg" class="kp-notebook-cover-image kp-notebook-cover-image-border"></div>
                         </div>
-                        <h1 class="a-size-base a-color-base a-text-center a-text-bold">REWORK - Réussir autrement (French Edition)</h1>
-                        <h1 class="a-size-base a-spacing-base a-spacing-top-mini a-color-secondary a-text-center">By: Jason FRIED and David HEINEMEIER HANSSON</h1>
-                      </a></span><input type="hidden" value="Tuesday June 20, 2017" id="kp-notebook-annotated-date-B004EYT2FC">
+                        <h2 class="a-size-base a-color-base a-text-center a-text-bold">REWORK - Réussir autrement (French Edition)</h2>
+                        <p class="a-spacing-base a-spacing-top-mini a-text-center a-size-base a-color-secondary">著者: Jason FRIED、David HEINEMEIER HANSSON</p>
+                      </a></span><input type="hidden" value="火曜日 6月 20, 2017" id="kp-notebook-annotated-date-B004EYT2FC">
                   </div>
                   <div id="B0026OR2TU" class="a-row kp-notebook-library-each-book">
                     <span class="a-declarative" data-action="get-annotations-for-asin" data-get-annotations-for-asin='{"asin":"B0026OR2TU"}'><a class="a-link-normal a-text-normal">
                         <div class="a-row">
                           <div class="a-column a-span4 a-push4 a-spacing-medium a-spacing-top-medium"><img src="https://images-na.ssl-images-amazon.com/images/I/918CYLkKo0L._SY160.jpg" class="kp-notebook-cover-image kp-notebook-cover-image-border"></div>
                         </div>
-                        <h1 class="a-size-base a-color-base a-text-center a-text-bold">Rails Cookbook: Recipes for Rapid Web Development with Ruby (Cookbooks (O'Reilly))</h1>
-                        <h1 class="a-size-base a-spacing-base a-spacing-top-mini a-color-secondary a-text-center">By: Rob Orsini</h1>
-                      </a></span><input type="hidden" value="Tuesday June 20, 2017" id="kp-notebook-annotated-date-B0026OR2TU">
+                        <h2 class="a-size-base a-color-base a-text-center a-text-bold">Rails Cookbook: Recipes for Rapid Web Development with Ruby (Cookbooks (O'Reilly))</h2>
+                        <p class="a-spacing-base a-spacing-top-mini a-text-center a-size-base a-color-secondary">著者: Rob Orsini</p>
+                      </a></span><input type="hidden" value="火曜日 6月 20, 2017" id="kp-notebook-annotated-date-B0026OR2TU">
                   </div>
                   <div id="B019IQOFRK" class="a-row kp-notebook-library-each-book">
                     <span class="a-declarative" data-action="get-annotations-for-asin" data-get-annotations-for-asin='{"asin":"B019IQOFRK"}'><a class="a-link-normal a-text-normal">
                         <div class="a-row">
                           <div class="a-column a-span4 a-push4 a-spacing-medium a-spacing-top-medium"><img src="https://images-na.ssl-images-amazon.com/images/I/81NZ-HF3alL._SY160.jpg" class="kp-notebook-cover-image kp-notebook-cover-image-border"></div>
                         </div>
-                        <h1 class="a-size-base a-color-base a-text-center a-text-bold">UML Essencial: Um Breve Guia para a Linguagem-Padrao de Modelagem de Objetos (Portuguese Edition)</h1>
-                        <h1 class="a-size-base a-spacing-base a-spacing-top-mini a-color-secondary a-text-center">By: Martin Fowler</h1>
-                      </a></span><input type="hidden" value="Tuesday June 20, 2017" id="kp-notebook-annotated-date-B019IQOFRK">
+                        <h2 class="a-size-base a-color-base a-text-center a-text-bold">UML Essencial: Um Breve Guia para a Linguagem-Padrao de Modelagem de Objetos (Portuguese Edition)</h2>
+                        <p class="a-spacing-base a-spacing-top-mini a-text-center a-size-base a-color-secondary">著者: Martin Fowler</p>
+                      </a></span><input type="hidden" value="火曜日 6月 20, 2017" id="kp-notebook-annotated-date-B019IQOFRK">
                   </div>
                   <div id="B00K711ABA" class="a-row kp-notebook-library-each-book">
                     <span class="a-declarative" data-action="get-annotations-for-asin" data-get-annotations-for-asin='{"asin":"B00K711ABA"}'><a class="a-link-normal a-text-normal">
                         <div class="a-row">
                           <div class="a-column a-span4 a-push4 a-spacing-medium a-spacing-top-medium"><img src="https://images-na.ssl-images-amazon.com/images/I/71%2Bmuxrb9zL._SY160.jpg" class="kp-notebook-cover-image kp-notebook-cover-image-border"></div>
                         </div>
-                        <h1 class="a-size-base a-color-base a-text-center a-text-bold">Remembering the Kanji 1 (Kindle Fire edition): A Complete Course on How Not to Forget the Meaning and Writing of Japanese Characters</h1>
-                        <h1 class="a-size-base a-spacing-base a-spacing-top-mini a-color-secondary a-text-center">By: James W. Heisig</h1>
-                      </a></span><input type="hidden" value="Wednesday February 11, 2015" id="kp-notebook-annotated-date-B00K711ABA">
+                        <h2 class="a-size-base a-color-base a-text-center a-text-bold">Remembering the Kanji 1 (Kindle Fire edition): A Complete Course on How Not to Forget the Meaning and Writing of Japanese Characters</h2>
+                        <p class="a-spacing-base a-spacing-top-mini a-text-center a-size-base a-color-secondary">著者: James W. Heisig</p>
+                      </a></span><input type="hidden" value="水曜日 2月 11, 2015" id="kp-notebook-annotated-date-B00K711ABA">
                   </div>
                   <div id="B00C0ALZ0W" class="a-row kp-notebook-library-each-book">
                     <span class="a-declarative" data-action="get-annotations-for-asin" data-get-annotations-for-asin='{"asin":"B00C0ALZ0W"}'><a class="a-link-normal a-text-normal">
                         <div class="a-row">
                           <div class="a-column a-span4 a-push4 a-spacing-medium a-spacing-top-medium"><img src="https://images-na.ssl-images-amazon.com/images/I/718BesFEZ5L._SY160.jpg" class="kp-notebook-cover-image kp-notebook-cover-image-border"></div>
                         </div>
-                        <h1 class="a-size-base a-color-base a-text-center a-text-bold">Remote: Office Not Required</h1>
-                        <h1 class="a-size-base a-spacing-base a-spacing-top-mini a-color-secondary a-text-center">By: Jason Fried and David Heinemeier Hansson</h1>
-                      </a></span><input type="hidden" value="Wednesday February 11, 2015" id="kp-notebook-annotated-date-B00C0ALZ0W">
+                        <h2 class="a-size-base a-color-base a-text-center a-text-bold">Remote: Office Not Required</h2>
+                        <p class="a-spacing-base a-spacing-top-mini a-text-center a-size-base a-color-secondary">著者: Jason Fried、David Heinemeier Hansson</p>
+                      </a></span><input type="hidden" value="水曜日 2月 11, 2015" id="kp-notebook-annotated-date-B00C0ALZ0W">
                   </div>
                   <input type="hidden" class="kp-notebook-library-next-page-start">
                 </div>
@@ -158,7 +160,7 @@
                   <div class="a-box a-alert-inline a-alert-inline-error kp-notebook-error-msg">
                     <div class="a-box-inner a-alert-container">
                       <i class="a-icon a-icon-alert"></i>
-                      <div class="a-alert-content">Sorry, we''ve experienced a problem. Please try again.</div>
+                      <div class="a-alert-content">申し訳ありませんが、問題が発生しました。もう一度お試しください。</div>
                     </div>
                   </div>
                 </div>
@@ -174,35 +176,44 @@
                       <div class="a-row a-spacing-base">
                         <div class="a-column a-span1 kp-notebook-bookcover-container"><a class="a-link-normal kp-notebook-printable a-text-normal" target="_blank" rel="noopener" href="https://www.amazon.com/dp/B004YW6M6G"><span class="a-declarative" data-action="kp-notebook-detail-page-url" data-kp-notebook-detail-page-url="{}"><img src="https://images-na.ssl-images-amazon.com/images/I/51inXHEQAJL._SY160.jpg" class="kp-notebook-cover-image-border"></span></a></div>
                         <div class="a-column a-span5">
-                          <h6 class="a-color-base kp-notebook-selectable kp-notebook-metadata a-text-bold">Your Kindle Notes For:</h6>
+                          <p class="a-spacing-small a-size-mini a-color-base kp-notebook-selectable kp-notebook-metadata a-text-bold a-text-caps">メモ付きのKindle本:</p>
                           <h3 class="a-spacing-top-small a-color-base kp-notebook-selectable kp-notebook-metadata">Design Patterns in Ruby (Adobe Reader) (Addison-Wesley Professional Ruby Series)</h3>
-                          <h1 class="a-size-base a-spacing-top-micro a-color-secondary kp-notebook-selectable kp-notebook-metadata">Russ Olsen</h1>
-                          <span class="a-size-small a-color-secondary kp-notebook-selectable kp-notebook-metadata">Last annotated on <span id="kp-notebook-annotated-date">Wednesday June 21, 2017</span></span>
+                          <p class="a-spacing-none a-spacing-top-micro a-size-base a-color-secondary kp-notebook-selectable kp-notebook-metadata">Russ Olsen</p>
+                          <span class="a-size-small a-color-secondary kp-notebook-selectable kp-notebook-metadata">注釈の最終更新日:  <span id="kp-notebook-annotated-date">水曜日 6月 21, 2017</span></span>
                         </div>
                       </div>
                       <div class="a-row a-spacing-large">
                         <div class="a-column a-span10 kp-notebook-row-separator">
-                          <h1 class="a-size-base-plus a-spacing-mini a-color-base kp-notebook-selectable kp-notebook-metadata a-text-bold">
-                            <span id="kp-notebook-highlights-count">8</span> Highlight(s)<font color="gray"> | </font>
-                            <span id="kp-notebook-notes-count">7</span> Note(s)</h1>
+                          <span class="a-size-base-plus a-color-base kp-notebook-selectable kp-notebook-metadata a-text-bold"><span id="kp-notebook-highlights-count">8</span> 個のハイライト<font color="gray"> | </font>
+                            <span id="kp-notebook-notes-count">7</span> 個のメモ</span>
+                          <div id="kp-notebook-hidden-annotations-summary" class="a-box a-alert-inline a-alert-inline-warning aok-hidden a-spacing-top-null">
+                            <div class="a-box-inner a-alert-container">
+                              <i class="a-icon a-icon-alert"></i>
+                              <div class="a-alert-content">エクスポートの制限に達したため、一部のハイライトが非表示になっているか、省略されています。</div>
+                            </div>
+                          </div>
                         </div>
                       </div>
                       <div id="kp-notebook-annotations" class="a-row">
+                        <input type="hidden" value="kWdDmwT2GK3c1a+Hjfpr88OTsBxXUpKzRSBbl+uOltQju3+IIZ1m" class="kp-notebook-content-limit-state"><input type="hidden" class="kp-notebook-annotations-next-page-start">
                         <div id="QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1MjM5MzpISUdITElHSFQ=" class="a-row a-spacing-base">
                           <div class="a-column a-span10 kp-notebook-row-separator">
                             <div class="a-row">
                               <input type="hidden" value="350" id="kp-annotation-location">
                               <div class="a-column a-span8">
-                                <span id="annotationHighlightHeader" class="a-size-small a-color-secondary kp-notebook-selectable kp-notebook-metadata">Orange highlight | Location: 350</span>
-                                <span id="annotationNoteHeader" class="a-size-small a-color-secondary aok-hidden kp-notebook-selectable kp-notebook-metadata">Note | Location: 350</span>
+                                <span id="annotationHighlightHeader" class="a-size-small a-color-secondary kp-notebook-selectable kp-notebook-metadata">オレンジ色のハイライト | 位置: 350</span>
+                                <span id="annotationNoteHeader" class="a-size-small a-color-secondary aok-hidden kp-notebook-selectable kp-notebook-metadata">メモ | 位置: 350</span>
                               </div>
-                              <div class="a-column a-span4 a-text-right a-span-last"><span class="a-declarative" data-action="a-popover" data-a-popover='{"closeButton":"false","closeButtonLabel":"Close","activate":"onclick","width":"200","name":"optionsPopover","position":"triggerVerticalAlignLeft","popoverLabel":"Options for annotations at Location 350"}' id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1MjM5MzpISUdITElHSFQ=-action"><a id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1MjM5MzpISUdITElHSFQ=" class="a-popover-trigger a-declarative">Options<i class="a-icon a-icon-popover"></i></a></span></div>
+                              <div class="a-column a-span4 a-text-right a-span-last"><span class="a-declarative" data-action="a-popover" data-a-popover='{"closeButton":"false","closeButtonLabel":"閉じる","activate":"onclick","width":"200","name":"optionsPopover","position":"triggerVerticalAlignLeft","popoverLabel":"注釈のためのオプション　ロケーション350"}' id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1MjM5MzpISUdITElHSFQ=-action"><a id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1MjM5MzpISUdITElHSFQ=" class="a-popover-trigger a-declarative">オプション<i class="a-icon a-icon-popover"></i></a></span></div>
                             </div>
                             <div class="a-row a-spacing-top-medium">
                               <div class="a-column a-span10 a-spacing-small kp-notebook-print-override">
-                                <div id="highlight-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1MjM5MzpISUdITElHSFQ=" class="a-row kp-notebook-highlight kp-notebook-selectable kp-notebook-highlight-orange"><span id="highlight" class="a-size-base-plus a-color-base">Design Patterns: Elements of Reusable Object-Oriented Software,</span></div>
+                                <div id="highlight-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1MjM5MzpISUdITElHSFQ=" class="a-row kp-notebook-highlight kp-notebook-selectable kp-notebook-highlight-orange">
+                                  <span id="highlight" class="a-size-base-plus a-color-base">Design Patterns: Elements of Reusable Object-Oriented Software,</span>
+                                  <div></div>
+                                </div>
                                 <div id="note-" class="a-row a-spacing-top-base kp-notebook-note aok-hidden kp-notebook-selectable">
-                                  <span id="note-label" class="a-size-small a-color-secondary">Note:<span class="a-letter-space"></span></span><span id="note" class="a-size-base-plus a-color-base"></span>
+                                  <span id="note-label" class="a-size-small a-color-secondary">メモ<span class="a-letter-space"></span></span><span id="note" class="a-size-base-plus a-color-base"></span>
                                 </div>
                               </div>
                             </div>
@@ -213,16 +224,19 @@
                             <div class="a-row">
                               <input type="hidden" value="351" id="kp-annotation-location">
                               <div class="a-column a-span8">
-                                <span id="annotationHighlightHeader" class="a-size-small a-color-secondary kp-notebook-selectable kp-notebook-metadata">Yellow highlight | Location: 351</span>
-                                <span id="annotationNoteHeader" class="a-size-small a-color-secondary aok-hidden kp-notebook-selectable kp-notebook-metadata">Note | Location: 351</span>
+                                <span id="annotationHighlightHeader" class="a-size-small a-color-secondary kp-notebook-selectable kp-notebook-metadata">黄色のハイライト | 位置: 351</span>
+                                <span id="annotationNoteHeader" class="a-size-small a-color-secondary aok-hidden kp-notebook-selectable kp-notebook-metadata">メモ | 位置: 351</span>
                               </div>
-                              <div class="a-column a-span4 a-text-right a-span-last"><span class="a-declarative" data-action="a-popover" data-a-popover='{"closeButton":"false","closeButtonLabel":"Close","activate":"onclick","width":"200","name":"optionsPopover","position":"triggerVerticalAlignLeft","popoverLabel":"Options for annotations at Location 351"}' id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1MjUwNDpISUdITElHSFQ=-action"><a id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1MjUwNDpISUdITElHSFQ=" class="a-popover-trigger a-declarative">Options<i class="a-icon a-icon-popover"></i></a></span></div>
+                              <div class="a-column a-span4 a-text-right a-span-last"><span class="a-declarative" data-action="a-popover" data-a-popover='{"closeButton":"false","closeButtonLabel":"閉じる","activate":"onclick","width":"200","name":"optionsPopover","position":"triggerVerticalAlignLeft","popoverLabel":"注釈のためのオプション　ロケーション351"}' id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1MjUwNDpISUdITElHSFQ=-action"><a id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1MjUwNDpISUdITElHSFQ=" class="a-popover-trigger a-declarative">オプション<i class="a-icon a-icon-popover"></i></a></span></div>
                             </div>
                             <div class="a-row a-spacing-top-medium">
                               <div class="a-column a-span10 a-spacing-small kp-notebook-print-override">
-                                <div id="highlight-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1MjUwNDpISUdITElHSFQ=" class="a-row kp-notebook-highlight kp-notebook-selectable kp-notebook-highlight-yellow"><span id="highlight" class="a-size-base-plus a-color-base">"Gang of Four book" (GoF)</span></div>
+                                <div id="highlight-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1MjUwNDpISUdITElHSFQ=" class="a-row kp-notebook-highlight kp-notebook-selectable kp-notebook-highlight-yellow">
+                                  <span id="highlight" class="a-size-base-plus a-color-base">"Gang of Four book" (GoF)</span>
+                                  <div></div>
+                                </div>
                                 <div id="note-" class="a-row a-spacing-top-base kp-notebook-note aok-hidden kp-notebook-selectable">
-                                  <span id="note-label" class="a-size-small a-color-secondary">Note:<span class="a-letter-space"></span></span><span id="note" class="a-size-base-plus a-color-base"></span>
+                                  <span id="note-label" class="a-size-small a-color-secondary">メモ<span class="a-letter-space"></span></span><span id="note" class="a-size-base-plus a-color-base"></span>
                                 </div>
                               </div>
                             </div>
@@ -233,16 +247,19 @@
                             <div class="a-row">
                               <input type="hidden" value="355" id="kp-annotation-location">
                               <div class="a-column a-span8">
-                                <span id="annotationHighlightHeader" class="a-size-small a-color-secondary kp-notebook-selectable kp-notebook-metadata">Yellow highlight | Location: 355</span>
-                                <span id="annotationNoteHeader" class="a-size-small a-color-secondary aok-hidden kp-notebook-selectable kp-notebook-metadata">Note | Location: 355</span>
+                                <span id="annotationHighlightHeader" class="a-size-small a-color-secondary kp-notebook-selectable kp-notebook-metadata">黄色のハイライト | 位置: 355</span>
+                                <span id="annotationNoteHeader" class="a-size-small a-color-secondary aok-hidden kp-notebook-selectable kp-notebook-metadata">メモ | 位置: 355</span>
                               </div>
-                              <div class="a-column a-span4 a-text-right a-span-last"><span class="a-declarative" data-action="a-popover" data-a-popover='{"closeButton":"false","closeButtonLabel":"Close","activate":"onclick","width":"200","name":"optionsPopover","position":"triggerVerticalAlignLeft","popoverLabel":"Options for annotations at Location 355"}' id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1MzE5MTpISUdITElHSFQ=-action"><a id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1MzE5MTpISUdITElHSFQ=" class="a-popover-trigger a-declarative">Options<i class="a-icon a-icon-popover"></i></a></span></div>
+                              <div class="a-column a-span4 a-text-right a-span-last"><span class="a-declarative" data-action="a-popover" data-a-popover='{"closeButton":"false","closeButtonLabel":"閉じる","activate":"onclick","width":"200","name":"optionsPopover","position":"triggerVerticalAlignLeft","popoverLabel":"注釈のためのオプション　ロケーション355"}' id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1MzE5MTpISUdITElHSFQ=-action"><a id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1MzE5MTpISUdITElHSFQ=" class="a-popover-trigger a-declarative">オプション<i class="a-icon a-icon-popover"></i></a></span></div>
                             </div>
                             <div class="a-row a-spacing-top-medium">
                               <div class="a-column a-span10 a-spacing-small kp-notebook-print-override">
-                                <div id="highlight-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1MzE5MTpISUdITElHSFQ=" class="a-row kp-notebook-highlight kp-notebook-selectable kp-notebook-highlight-yellow"><span id="highlight" class="a-size-base-plus a-color-base">the most useful thing about patterns is the way in which they form a vocabulary for articulating design decisions during the normal course of development conversations among programmers.</span></div>
+                                <div id="highlight-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1MzE5MTpISUdITElHSFQ=" class="a-row kp-notebook-highlight kp-notebook-selectable kp-notebook-highlight-yellow">
+                                  <span id="highlight" class="a-size-base-plus a-color-base">the most useful thing about patterns is the way in which they form a vocabulary for articulating design decisions during the normal course of development conversations among programmers.</span>
+                                  <div></div>
+                                </div>
                                 <div id="note-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1MzI2OTpOT1RF" class="a-row a-spacing-top-base kp-notebook-note kp-notebook-selectable">
-                                  <span id="note-label" class="a-size-small a-color-secondary">Note:<span class="a-letter-space"></span></span><span id="note" class="a-size-base-plus a-color-base">note 1</span>
+                                  <span id="note-label" class="a-size-small a-color-secondary">メモ<span class="a-letter-space"></span></span><span id="note" class="a-size-base-plus a-color-base">note 1</span>
                                 </div>
                               </div>
                             </div>
@@ -253,9 +270,9 @@
                             <div class="a-row">
                               <input type="hidden" value="356" id="kp-annotation-location">
                               <div class="a-column a-span8">
-                                <span id="annotationNoteHeader" class="a-size-small a-color-secondary kp-notebook-selectable kp-notebook-metadata">Note | Location: 356</span>
+                                <span id="annotationNoteHeader" class="a-size-small a-color-secondary kp-notebook-selectable kp-notebook-metadata">メモ | 位置: 356</span>
                               </div>
-                              <div class="a-column a-span4 a-text-right a-span-last"><span class="a-declarative" data-action="a-popover" data-a-popover='{"closeButton":"false","closeButtonLabel":"Close","activate":"onclick","width":"200","name":"optionsPopover","position":"triggerVerticalAlignLeft","popoverLabel":"Options for annotations at Location 356"}' id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1MzM0MzpOT1RF-action"><a id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1MzM0MzpOT1RF" class="a-popover-trigger a-declarative">Options<i class="a-icon a-icon-popover"></i></a></span></div>
+                              <div class="a-column a-span4 a-text-right a-span-last"><span class="a-declarative" data-action="a-popover" data-a-popover='{"closeButton":"false","closeButtonLabel":"閉じる","activate":"onclick","width":"200","name":"optionsPopover","position":"triggerVerticalAlignLeft","popoverLabel":"注釈のためのオプション　ロケーション356"}' id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1MzM0MzpOT1RF-action"><a id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1MzM0MzpOT1RF" class="a-popover-trigger a-declarative">オプション<i class="a-icon a-icon-popover"></i></a></span></div>
                             </div>
                             <div class="a-row a-spacing-top-medium">
                               <div class="a-column a-span10 a-spacing-small kp-notebook-print-override">
@@ -269,16 +286,19 @@
                             <div class="a-row">
                               <input type="hidden" value="357" id="kp-annotation-location">
                               <div class="a-column a-span8">
-                                <span id="annotationHighlightHeader" class="a-size-small a-color-secondary kp-notebook-selectable kp-notebook-metadata">Blue highlight | Location: 357</span>
-                                <span id="annotationNoteHeader" class="a-size-small a-color-secondary aok-hidden kp-notebook-selectable kp-notebook-metadata">Note | Location: 357</span>
+                                <span id="annotationHighlightHeader" class="a-size-small a-color-secondary kp-notebook-selectable kp-notebook-metadata">青色のハイライト | 位置: 357</span>
+                                <span id="annotationNoteHeader" class="a-size-small a-color-secondary aok-hidden kp-notebook-selectable kp-notebook-metadata">メモ | 位置: 357</span>
                               </div>
-                              <div class="a-column a-span4 a-text-right a-span-last"><span class="a-declarative" data-action="a-popover" data-a-popover='{"closeButton":"false","closeButtonLabel":"Close","activate":"onclick","width":"200","name":"optionsPopover","position":"triggerVerticalAlignLeft","popoverLabel":"Options for annotations at Location 357"}' id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1MzQ0NDpISUdITElHSFQ=-action"><a id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1MzQ0NDpISUdITElHSFQ=" class="a-popover-trigger a-declarative">Options<i class="a-icon a-icon-popover"></i></a></span></div>
+                              <div class="a-column a-span4 a-text-right a-span-last"><span class="a-declarative" data-action="a-popover" data-a-popover='{"closeButton":"false","closeButtonLabel":"閉じる","activate":"onclick","width":"200","name":"optionsPopover","position":"triggerVerticalAlignLeft","popoverLabel":"注釈のためのオプション　ロケーション357"}' id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1MzQ0NDpISUdITElHSFQ=-action"><a id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1MzQ0NDpISUdITElHSFQ=" class="a-popover-trigger a-declarative">オプション<i class="a-icon a-icon-popover"></i></a></span></div>
                             </div>
                             <div class="a-row a-spacing-top-medium">
                               <div class="a-column a-span10 a-spacing-small kp-notebook-print-override">
-                                <div id="highlight-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1MzQ0NDpISUdITElHSFQ=" class="a-row kp-notebook-highlight kp-notebook-selectable kp-notebook-highlight-blue"><span id="highlight" class="a-size-base-plus a-color-base">Extreme Programming</span></div>
+                                <div id="highlight-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1MzQ0NDpISUdITElHSFQ=" class="a-row kp-notebook-highlight kp-notebook-selectable kp-notebook-highlight-blue">
+                                  <span id="highlight" class="a-size-base-plus a-color-base">Extreme Programming</span>
+                                  <div></div>
+                                </div>
                                 <div id="note-" class="a-row a-spacing-top-base kp-notebook-note aok-hidden kp-notebook-selectable">
-                                  <span id="note-label" class="a-size-small a-color-secondary">Note:<span class="a-letter-space"></span></span><span id="note" class="a-size-base-plus a-color-base"></span>
+                                  <span id="note-label" class="a-size-small a-color-secondary">メモ<span class="a-letter-space"></span></span><span id="note" class="a-size-base-plus a-color-base"></span>
                                 </div>
                               </div>
                             </div>
@@ -289,9 +309,9 @@
                             <div class="a-row">
                               <input type="hidden" value="362" id="kp-annotation-location">
                               <div class="a-column a-span8">
-                                <span id="annotationNoteHeader" class="a-size-small a-color-secondary kp-notebook-selectable kp-notebook-metadata">Note | Location: 362</span>
+                                <span id="annotationNoteHeader" class="a-size-small a-color-secondary kp-notebook-selectable kp-notebook-metadata">メモ | 位置: 362</span>
                               </div>
-                              <div class="a-column a-span4 a-text-right a-span-last"><span class="a-declarative" data-action="a-popover" data-a-popover='{"closeButton":"false","closeButtonLabel":"Close","activate":"onclick","width":"200","name":"optionsPopover","position":"triggerVerticalAlignLeft","popoverLabel":"Options for annotations at Location 362"}' id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NDE4NzpOT1RF-action"><a id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NDE4NzpOT1RF" class="a-popover-trigger a-declarative">Options<i class="a-icon a-icon-popover"></i></a></span></div>
+                              <div class="a-column a-span4 a-text-right a-span-last"><span class="a-declarative" data-action="a-popover" data-a-popover='{"closeButton":"false","closeButtonLabel":"閉じる","activate":"onclick","width":"200","name":"optionsPopover","position":"triggerVerticalAlignLeft","popoverLabel":"注釈のためのオプション　ロケーション362"}' id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NDE4NzpOT1RF-action"><a id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NDE4NzpOT1RF" class="a-popover-trigger a-declarative">オプション<i class="a-icon a-icon-popover"></i></a></span></div>
                             </div>
                             <div class="a-row a-spacing-top-medium">
                               <div class="a-column a-span10 a-spacing-small kp-notebook-print-override">
@@ -305,16 +325,19 @@
                             <div class="a-row">
                               <input type="hidden" value="364" id="kp-annotation-location">
                               <div class="a-column a-span8">
-                                <span id="annotationHighlightHeader" class="a-size-small a-color-secondary kp-notebook-selectable kp-notebook-metadata">Pink highlight | Location: 364</span>
-                                <span id="annotationNoteHeader" class="a-size-small a-color-secondary aok-hidden kp-notebook-selectable kp-notebook-metadata">Note | Location: 364</span>
+                                <span id="annotationHighlightHeader" class="a-size-small a-color-secondary kp-notebook-selectable kp-notebook-metadata">ピンク色のハイライト | 位置: 364</span>
+                                <span id="annotationNoteHeader" class="a-size-small a-color-secondary aok-hidden kp-notebook-selectable kp-notebook-metadata">メモ | 位置: 364</span>
                               </div>
-                              <div class="a-column a-span4 a-text-right a-span-last"><span class="a-declarative" data-action="a-popover" data-a-popover='{"closeButton":"false","closeButtonLabel":"Close","activate":"onclick","width":"200","name":"optionsPopover","position":"triggerVerticalAlignLeft","popoverLabel":"Options for annotations at Location 364"}' id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NDQ2NjpISUdITElHSFQ=-action"><a id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NDQ2NjpISUdITElHSFQ=" class="a-popover-trigger a-declarative">Options<i class="a-icon a-icon-popover"></i></a></span></div>
+                              <div class="a-column a-span4 a-text-right a-span-last"><span class="a-declarative" data-action="a-popover" data-a-popover='{"closeButton":"false","closeButtonLabel":"閉じる","activate":"onclick","width":"200","name":"optionsPopover","position":"triggerVerticalAlignLeft","popoverLabel":"注釈のためのオプション　ロケーション364"}' id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NDQ2NjpISUdITElHSFQ=-action"><a id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NDQ2NjpISUdITElHSFQ=" class="a-popover-trigger a-declarative">オプション<i class="a-icon a-icon-popover"></i></a></span></div>
                             </div>
                             <div class="a-row a-spacing-top-medium">
                               <div class="a-column a-span10 a-spacing-small kp-notebook-print-override">
-                                <div id="highlight-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NDQ2NjpISUdITElHSFQ=" class="a-row kp-notebook-highlight kp-notebook-selectable kp-notebook-highlight-pink"><span id="highlight" class="a-size-base-plus a-color-base">having a favorite pattern is kind of strange isn’t it?</span></div>
+                                <div id="highlight-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NDQ2NjpISUdITElHSFQ=" class="a-row kp-notebook-highlight kp-notebook-selectable kp-notebook-highlight-pink">
+                                  <span id="highlight" class="a-size-base-plus a-color-base">having a favorite pattern is kind of strange isn’t it?</span>
+                                  <div></div>
+                                </div>
                                 <div id="note-" class="a-row a-spacing-top-base kp-notebook-note aok-hidden kp-notebook-selectable">
-                                  <span id="note-label" class="a-size-small a-color-secondary">Note:<span class="a-letter-space"></span></span><span id="note" class="a-size-base-plus a-color-base"></span>
+                                  <span id="note-label" class="a-size-small a-color-secondary">メモ<span class="a-letter-space"></span></span><span id="note" class="a-size-base-plus a-color-base"></span>
                                 </div>
                               </div>
                             </div>
@@ -325,16 +348,19 @@
                             <div class="a-row">
                               <input type="hidden" value="366" id="kp-annotation-location">
                               <div class="a-column a-span8">
-                                <span id="annotationHighlightHeader" class="a-size-small a-color-secondary kp-notebook-selectable kp-notebook-metadata">Pink highlight | Location: 366</span>
-                                <span id="annotationNoteHeader" class="a-size-small a-color-secondary aok-hidden kp-notebook-selectable kp-notebook-metadata">Note | Location: 366</span>
+                                <span id="annotationHighlightHeader" class="a-size-small a-color-secondary kp-notebook-selectable kp-notebook-metadata">ピンク色のハイライト | 位置: 366</span>
+                                <span id="annotationNoteHeader" class="a-size-small a-color-secondary aok-hidden kp-notebook-selectable kp-notebook-metadata">メモ | 位置: 366</span>
                               </div>
-                              <div class="a-column a-span4 a-text-right a-span-last"><span class="a-declarative" data-action="a-popover" data-a-popover='{"closeButton":"false","closeButtonLabel":"Close","activate":"onclick","width":"200","name":"optionsPopover","position":"triggerVerticalAlignLeft","popoverLabel":"Options for annotations at Location 366"}' id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NDgwNzpISUdITElHSFQ=-action"><a id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NDgwNzpISUdITElHSFQ=" class="a-popover-trigger a-declarative">Options<i class="a-icon a-icon-popover"></i></a></span></div>
+                              <div class="a-column a-span4 a-text-right a-span-last"><span class="a-declarative" data-action="a-popover" data-a-popover='{"closeButton":"false","closeButtonLabel":"閉じる","activate":"onclick","width":"200","name":"optionsPopover","position":"triggerVerticalAlignLeft","popoverLabel":"注釈のためのオプション　ロケーション366"}' id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NDgwNzpISUdITElHSFQ=-action"><a id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NDgwNzpISUdITElHSFQ=" class="a-popover-trigger a-declarative">オプション<i class="a-icon a-icon-popover"></i></a></span></div>
                             </div>
                             <div class="a-row a-spacing-top-medium">
                               <div class="a-column a-span10 a-spacing-small kp-notebook-print-override">
-                                <div id="highlight-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NDgwNzpISUdITElHSFQ=" class="a-row kp-notebook-highlight kp-notebook-selectable kp-notebook-highlight-pink"><span id="highlight" class="a-size-base-plus a-color-base">Why do people get wrapped up in implementing patterns "just for fun" anyway?</span></div>
+                                <div id="highlight-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NDgwNzpISUdITElHSFQ=" class="a-row kp-notebook-highlight kp-notebook-selectable kp-notebook-highlight-pink">
+                                  <span id="highlight" class="a-size-base-plus a-color-base">Why do people get wrapped up in implementing patterns "just for fun" anyway?</span>
+                                  <div></div>
+                                </div>
                                 <div id="note-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NDg2OTpOT1RF" class="a-row a-spacing-top-base kp-notebook-note kp-notebook-selectable">
-                                  <span id="note-label" class="a-size-small a-color-secondary">Note:<span class="a-letter-space"></span></span><span id="note" class="a-size-base-plus a-color-base">test note</span>
+                                  <span id="note-label" class="a-size-small a-color-secondary">メモ<span class="a-letter-space"></span></span><span id="note" class="a-size-base-plus a-color-base">test note</span>
                                 </div>
                               </div>
                             </div>
@@ -345,16 +371,19 @@
                             <div class="a-row">
                               <input type="hidden" value="368" id="kp-annotation-location">
                               <div class="a-column a-span8">
-                                <span id="annotationHighlightHeader" class="a-size-small a-color-secondary kp-notebook-selectable kp-notebook-metadata">Yellow highlight | Location: 368</span>
-                                <span id="annotationNoteHeader" class="a-size-small a-color-secondary aok-hidden kp-notebook-selectable kp-notebook-metadata">Note | Location: 368</span>
+                                <span id="annotationHighlightHeader" class="a-size-small a-color-secondary kp-notebook-selectable kp-notebook-metadata">黄色のハイライト | 位置: 368</span>
+                                <span id="annotationNoteHeader" class="a-size-small a-color-secondary aok-hidden kp-notebook-selectable kp-notebook-metadata">メモ | 位置: 368</span>
                               </div>
-                              <div class="a-column a-span4 a-text-right a-span-last"><span class="a-declarative" data-action="a-popover" data-a-popover='{"closeButton":"false","closeButtonLabel":"Close","activate":"onclick","width":"200","name":"optionsPopover","position":"triggerVerticalAlignLeft","popoverLabel":"Options for annotations at Location 368"}' id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NTE0MjpISUdITElHSFQ=-action"><a id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NTE0MjpISUdITElHSFQ=" class="a-popover-trigger a-declarative">Options<i class="a-icon a-icon-popover"></i></a></span></div>
+                              <div class="a-column a-span4 a-text-right a-span-last"><span class="a-declarative" data-action="a-popover" data-a-popover='{"closeButton":"false","closeButtonLabel":"閉じる","activate":"onclick","width":"200","name":"optionsPopover","position":"triggerVerticalAlignLeft","popoverLabel":"注釈のためのオプション　ロケーション368"}' id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NTE0MjpISUdITElHSFQ=-action"><a id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NTE0MjpISUdITElHSFQ=" class="a-popover-trigger a-declarative">オプション<i class="a-icon a-icon-popover"></i></a></span></div>
                             </div>
                             <div class="a-row a-spacing-top-medium">
                               <div class="a-column a-span10 a-spacing-small kp-notebook-print-override">
-                                <div id="highlight-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NTE0MjpISUdITElHSFQ=" class="a-row kp-notebook-highlight kp-notebook-selectable kp-notebook-highlight-yellow"><span id="highlight" class="a-size-base-plus a-color-base">ninja techniques</span></div>
+                                <div id="highlight-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NTE0MjpISUdITElHSFQ=" class="a-row kp-notebook-highlight kp-notebook-selectable kp-notebook-highlight-yellow">
+                                  <span id="highlight" class="a-size-base-plus a-color-base">ninja techniques</span>
+                                  <div></div>
+                                </div>
                                 <div id="note-" class="a-row a-spacing-top-base kp-notebook-note aok-hidden kp-notebook-selectable">
-                                  <span id="note-label" class="a-size-small a-color-secondary">Note:<span class="a-letter-space"></span></span><span id="note" class="a-size-base-plus a-color-base"></span>
+                                  <span id="note-label" class="a-size-small a-color-secondary">メモ<span class="a-letter-space"></span></span><span id="note" class="a-size-base-plus a-color-base"></span>
                                 </div>
                               </div>
                             </div>
@@ -365,16 +394,19 @@
                             <div class="a-row">
                               <input type="hidden" value="373" id="kp-annotation-location">
                               <div class="a-column a-span8">
-                                <span id="annotationHighlightHeader" class="a-size-small a-color-secondary kp-notebook-selectable kp-notebook-metadata">Yellow highlight | Location: 373</span>
-                                <span id="annotationNoteHeader" class="a-size-small a-color-secondary aok-hidden kp-notebook-selectable kp-notebook-metadata">Note | Location: 373</span>
+                                <span id="annotationHighlightHeader" class="a-size-small a-color-secondary kp-notebook-selectable kp-notebook-metadata">黄色のハイライト | 位置: 373</span>
+                                <span id="annotationNoteHeader" class="a-size-small a-color-secondary aok-hidden kp-notebook-selectable kp-notebook-metadata">メモ | 位置: 373</span>
                               </div>
-                              <div class="a-column a-span4 a-text-right a-span-last"><span class="a-declarative" data-action="a-popover" data-a-popover='{"closeButton":"false","closeButtonLabel":"Close","activate":"onclick","width":"200","name":"optionsPopover","position":"triggerVerticalAlignLeft","popoverLabel":"Options for annotations at Location 373"}' id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NTgwOTpISUdITElHSFQ=-action"><a id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NTgwOTpISUdITElHSFQ=" class="a-popover-trigger a-declarative">Options<i class="a-icon a-icon-popover"></i></a></span></div>
+                              <div class="a-column a-span4 a-text-right a-span-last"><span class="a-declarative" data-action="a-popover" data-a-popover='{"closeButton":"false","closeButtonLabel":"閉じる","activate":"onclick","width":"200","name":"optionsPopover","position":"triggerVerticalAlignLeft","popoverLabel":"注釈のためのオプション　ロケーション373"}' id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NTgwOTpISUdITElHSFQ=-action"><a id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NTgwOTpISUdITElHSFQ=" class="a-popover-trigger a-declarative">オプション<i class="a-icon a-icon-popover"></i></a></span></div>
                             </div>
                             <div class="a-row a-spacing-top-medium">
                               <div class="a-column a-span10 a-spacing-small kp-notebook-print-override">
-                                <div id="highlight-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NTgwOTpISUdITElHSFQ=" class="a-row kp-notebook-highlight kp-notebook-selectable kp-notebook-highlight-yellow"><span id="highlight" class="a-size-base-plus a-color-base">Command object in the GoF sense is essentially a wrapper around some code that knows how to do one specific thing,</span></div>
+                                <div id="highlight-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NTgwOTpISUdITElHSFQ=" class="a-row kp-notebook-highlight kp-notebook-selectable kp-notebook-highlight-yellow">
+                                  <span id="highlight" class="a-size-base-plus a-color-base">Command object in the GoF sense is essentially a wrapper around some code that knows how to do one specific thing,</span>
+                                  <div></div>
+                                </div>
                                 <div id="note-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NTg4MTpOT1RF" class="a-row a-spacing-top-base kp-notebook-note kp-notebook-selectable">
-                                  <span id="note-label" class="a-size-small a-color-secondary">Note:<span class="a-letter-space"></span></span><span id="note" class="a-size-base-plus a-color-base">test note</span>
+                                  <span id="note-label" class="a-size-small a-color-secondary">メモ<span class="a-letter-space"></span></span><span id="note" class="a-size-base-plus a-color-base">test note</span>
                                 </div>
                               </div>
                             </div>
@@ -385,9 +417,9 @@
                             <div class="a-row">
                               <input type="hidden" value="375" id="kp-annotation-location">
                               <div class="a-column a-span8">
-                                <span id="annotationNoteHeader" class="a-size-small a-color-secondary kp-notebook-selectable kp-notebook-metadata">Note | Location: 375</span>
+                                <span id="annotationNoteHeader" class="a-size-small a-color-secondary kp-notebook-selectable kp-notebook-metadata">メモ | 位置: 375</span>
                               </div>
-                              <div class="a-column a-span4 a-text-right a-span-last"><span class="a-declarative" data-action="a-popover" data-a-popover='{"closeButton":"false","closeButtonLabel":"Close","activate":"onclick","width":"200","name":"optionsPopover","position":"triggerVerticalAlignLeft","popoverLabel":"Options for annotations at Location 375"}' id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NjE5NTpOT1RF-action"><a id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NjE5NTpOT1RF" class="a-popover-trigger a-declarative">Options<i class="a-icon a-icon-popover"></i></a></span></div>
+                              <div class="a-column a-span4 a-text-right a-span-last"><span class="a-declarative" data-action="a-popover" data-a-popover='{"closeButton":"false","closeButtonLabel":"閉じる","activate":"onclick","width":"200","name":"optionsPopover","position":"triggerVerticalAlignLeft","popoverLabel":"注釈のためのオプション　ロケーション375"}' id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NjE5NTpOT1RF-action"><a id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NjE5NTpOT1RF" class="a-popover-trigger a-declarative">オプション<i class="a-icon a-icon-popover"></i></a></span></div>
                             </div>
                             <div class="a-row a-spacing-top-medium">
                               <div class="a-column a-span10 a-spacing-small kp-notebook-print-override">
@@ -401,9 +433,9 @@
                             <div class="a-row">
                               <input type="hidden" value="385" id="kp-annotation-location">
                               <div class="a-column a-span8">
-                                <span id="annotationNoteHeader" class="a-size-small a-color-secondary kp-notebook-selectable kp-notebook-metadata">Note | Location: 385</span>
+                                <span id="annotationNoteHeader" class="a-size-small a-color-secondary kp-notebook-selectable kp-notebook-metadata">メモ | 位置: 385</span>
                               </div>
-                              <div class="a-column a-span4 a-text-right a-span-last"><span class="a-declarative" data-action="a-popover" data-a-popover='{"closeButton":"false","closeButtonLabel":"Close","activate":"onclick","width":"200","name":"optionsPopover","position":"triggerVerticalAlignLeft","popoverLabel":"Options for annotations at Location 385"}' id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NzYzMDpOT1RF-action"><a id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NzYzMDpOT1RF" class="a-popover-trigger a-declarative">Options<i class="a-icon a-icon-popover"></i></a></span></div>
+                              <div class="a-column a-span4 a-text-right a-span-last"><span class="a-declarative" data-action="a-popover" data-a-popover='{"closeButton":"false","closeButtonLabel":"閉じる","activate":"onclick","width":"200","name":"optionsPopover","position":"triggerVerticalAlignLeft","popoverLabel":"注釈のためのオプション　ロケーション385"}' id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NzYzMDpOT1RF-action"><a id="popover-QTEyVDZSRFhONU85Nkw6QjAwNFlXNk02Rzo1NzYzMDpOT1RF" class="a-popover-trigger a-declarative">オプション<i class="a-icon a-icon-popover"></i></a></span></div>
                             </div>
                             <div class="a-row a-spacing-top-medium">
                               <div class="a-column a-span10 a-spacing-small kp-notebook-print-override">
@@ -412,17 +444,16 @@
                             </div>
                           </div>
                         </div>
-                        <input type="hidden" class="kp-notebook-annotations-next-page-start">
                         <div id="empty-annotations-pane" class="a-row aok-hidden">
                           <div class="a-column a-span6 a-push3">
-                            <div class="a-box a-spacing-top-extra-large a-box-normal a-color-base-background a-text-center">
+                            <div class="a-box a-spacing-top-extra-large a-box-normal a-text-center">
                               <div class="a-box-inner">
                                 <div class="a-row a-spacing-large a-spacing-top-medium">
                                   <div class="a-column a-span4 a-push4"><img src="img/Note_icon.png" class="kp-notebook-cover-image" height="44"></div>
                                 </div>
-                                <h3 class="a-spacing-medium">Would you like to take some notes?</h3>
-                                <span>You haven’t created any notes for this book yet. You can add or remove bookmarks, highlights, and notes at any location in a Kindle book. </span>
-                                <div class="a-row a-spacing-extra-large a-spacing-top-medium"><a class="a-link-emphasis" target="_blank" rel="noopener" href="https://www.amazon.com/gp/help/customer/display.html?nodeId=201241990">Learn more about notes and highlights</a></div>
+                                <p class="a-spacing-medium a-size-medium a-text-bold">メモを作成しますか?</p>
+                                <span>この本にはメモがありません。Kindle本やパーソナル・ドキュメントでは、ブックマーク、ハイライト、メモをいつでも追加または削除することができます。</span>
+                                <div class="a-row a-spacing-extra-large a-spacing-top-medium"><a class="a-link-emphasis" target="_blank" rel="noopener" href="https://www.amazon.com/gp/help/customer/display.html?nodeId=201241990">メモとハイライトの詳細についてはこちら</a></div>
                               </div>
                             </div>
                           </div>
@@ -433,7 +464,7 @@
                         <div class="a-box a-alert-inline a-alert-inline-error kp-notebook-error-msg">
                           <div class="a-box-inner a-alert-container">
                             <i class="a-icon a-icon-alert"></i>
-                            <div class="a-alert-content">Sorry, we''ve experienced a problem. Please try again.</div>
+                            <div class="a-alert-content">申し訳ありませんが、問題が発生しました。もう一度お試しください。</div>
                           </div>
                         </div>
                       </div>
@@ -442,42 +473,42 @@
                     </div>
                   </div>
                 </div>
-                <span class="a-declarative" data-action="a-modal" data-a-modal='{"footer":"&lt;span class=\"a-declarative\" data-action=\"a-popover-close\" data-a-popover-close=\"{}\"&gt;&lt;span class=\"a-button\"&gt;&lt;span class=\"a-button-inner\"&gt;&lt;input class=\"a-button-input\" type=\"submit\"&gt;&lt;span class=\"a-button-text a-text-center\" aria-hidden=\"true\"&gt;Cancel&lt;\/span&gt;&lt;\/span&gt;&lt;\/span&gt;&lt;\/span&gt;&lt;span class=\"a-declarative\" data-action=\"delete-highlight-action\" data-delete-highlight-action=\"{&amp;quot;deviceType&amp;quot;:&amp;quot;desktop&amp;quot;}\"&gt;&lt;span id=\"deleteHighlight\" class=\"a-button a-button-primary kp-notebook-modal-button\"&gt;&lt;span class=\"a-button-inner\"&gt;&lt;input class=\"a-button-input\" type=\"submit\" aria-labelledby=\"deleteHighlight-announce\"&gt;&lt;span id=\"deleteHighlight-announce\" class=\"a-button-text a-text-center\" aria-hidden=\"true\"&gt;Delete highlight&lt;\/span&gt;&lt;\/span&gt;&lt;\/span&gt;&lt;\/span&gt;","name":"deleteHighlightPreload","width":"600","header":"Delete Highlight"}' id="deleteHighlightModal"></span>
+                <span class="a-declarative" data-action="a-modal" data-a-modal='{"footer":"&lt;span class=\"a-declarative\" data-action=\"a-popover-close\" data-a-popover-close=\"{}\"&gt;&lt;span class=\"a-button\"&gt;&lt;span class=\"a-button-inner\"&gt;&lt;input class=\"a-button-input\" type=\"submit\"&gt;&lt;span class=\"a-button-text a-text-center\" aria-hidden=\"true\"&gt;キャンセル&lt;\/span&gt;&lt;\/span&gt;&lt;\/span&gt;&lt;\/span&gt;&lt;span class=\"a-declarative\" data-action=\"delete-highlight-action\" data-delete-highlight-action=\"{&amp;quot;deviceType&amp;quot;:&amp;quot;desktop&amp;quot;}\"&gt;&lt;span id=\"deleteHighlight\" class=\"a-button a-button-primary kp-notebook-modal-button\"&gt;&lt;span class=\"a-button-inner\"&gt;&lt;input class=\"a-button-input\" type=\"submit\" aria-labelledby=\"deleteHighlight-announce\"&gt;&lt;span id=\"deleteHighlight-announce\" class=\"a-button-text a-text-center\" aria-hidden=\"true\"&gt;ハイライトを削除する&lt;\/span&gt;&lt;\/span&gt;&lt;\/span&gt;&lt;\/span&gt;","name":"deleteHighlightPreload","width":"600","header":"ハイライトを削除"}' id="deleteHighlightModal"></span>
                 <div class="a-popover-preload" id="a-popover-deleteHighlightPreload">
-                  <h1 class="a-size-small a-color-base">Once you delete this highlight, it will be removed from all of your devices.</h1>
+                  <p class="a-spacing-none a-size-small a-color-base">このハイライトは、すべての端末から削除されます。</p>
                   <input type="hidden" id="deleteHighlightAnnotationId">
                   <div id="deleteHighlightError" class="a-row a-spacing-small a-spacing-top-small aok-hidden">
                     <div class="a-box a-alert-inline a-alert-inline-error">
                       <div class="a-box-inner a-alert-container">
                         <i class="a-icon a-icon-alert"></i>
-                        <div class="a-alert-content">Sorry, we''ve experienced a problem. Please try again.</div>
+                        <div class="a-alert-content">申し訳ありませんが、問題が発生しました。もう一度お試しください。</div>
                       </div>
                     </div>
                   </div>
                 </div>
-                <span class="a-declarative" data-action="a-modal" data-a-modal='{"footer":"&lt;span class=\"a-declarative\" data-action=\"a-popover-close\" data-a-popover-close=\"{}\"&gt;&lt;span class=\"a-button\"&gt;&lt;span class=\"a-button-inner\"&gt;&lt;input class=\"a-button-input\" type=\"submit\"&gt;&lt;span class=\"a-button-text a-text-center\" aria-hidden=\"true\"&gt;Cancel&lt;\/span&gt;&lt;\/span&gt;&lt;\/span&gt;&lt;\/span&gt;&lt;span class=\"a-declarative\" data-action=\"delete-note-action\" data-delete-note-action=\"{&amp;quot;deviceType&amp;quot;:&amp;quot;desktop&amp;quot;}\"&gt;&lt;span id=\"deleteNote\" class=\"a-button a-button-primary kp-notebook-modal-button\"&gt;&lt;span class=\"a-button-inner\"&gt;&lt;input class=\"a-button-input\" type=\"submit\" aria-labelledby=\"deleteNote-announce\"&gt;&lt;span id=\"deleteNote-announce\" class=\"a-button-text a-text-center\" aria-hidden=\"true\"&gt;Delete note&lt;\/span&gt;&lt;\/span&gt;&lt;\/span&gt;&lt;\/span&gt;","name":"deleteNotePreload","width":"600","header":"Delete Note"}' id="deleteNoteModal"></span>
+                <span class="a-declarative" data-action="a-modal" data-a-modal='{"footer":"&lt;span class=\"a-declarative\" data-action=\"a-popover-close\" data-a-popover-close=\"{}\"&gt;&lt;span class=\"a-button\"&gt;&lt;span class=\"a-button-inner\"&gt;&lt;input class=\"a-button-input\" type=\"submit\"&gt;&lt;span class=\"a-button-text a-text-center\" aria-hidden=\"true\"&gt;キャンセル&lt;\/span&gt;&lt;\/span&gt;&lt;\/span&gt;&lt;\/span&gt;&lt;span class=\"a-declarative\" data-action=\"delete-note-action\" data-delete-note-action=\"{&amp;quot;deviceType&amp;quot;:&amp;quot;desktop&amp;quot;}\"&gt;&lt;span id=\"deleteNote\" class=\"a-button a-button-primary kp-notebook-modal-button\"&gt;&lt;span class=\"a-button-inner\"&gt;&lt;input class=\"a-button-input\" type=\"submit\" aria-labelledby=\"deleteNote-announce\"&gt;&lt;span id=\"deleteNote-announce\" class=\"a-button-text a-text-center\" aria-hidden=\"true\"&gt;メモを削除する&lt;\/span&gt;&lt;\/span&gt;&lt;\/span&gt;&lt;\/span&gt;","name":"deleteNotePreload","width":"600","header":"メモを削除"}' id="deleteNoteModal"></span>
                 <div class="a-popover-preload" id="a-popover-deleteNotePreload">
-                  <h1 class="a-size-small a-color-base">Once you delete this note, it will be removed from all of your devices.</h1>
+                  <p class="a-spacing-none a-size-small a-color-base">このメモは、すべての端末から削除されます。</p>
                   <input type="hidden" id="deleteNoteAnnotationId">
                   <div id="deleteNoteError" class="a-row a-spacing-small a-spacing-top-small aok-hidden">
                     <div class="a-box a-alert-inline a-alert-inline-error">
                       <div class="a-box-inner a-alert-container">
                         <i class="a-icon a-icon-alert"></i>
-                        <div class="a-alert-content">Sorry, we''ve experienced a problem. Please try again.</div>
+                        <div class="a-alert-content">申し訳ありませんが、問題が発生しました。もう一度お試しください。</div>
                       </div>
                     </div>
                   </div>
                 </div>
-                <span class="a-declarative" data-action="a-modal" data-a-modal='{"name":"readMorePreload","width":"600","header":"Opening in Kindle"}' id="readMoreModal"></span>
+                <span class="a-declarative" data-action="a-modal" data-a-modal='{"name":"readMorePreload","width":"600","header":"Kindleで開く"}' id="readMoreModal"></span>
                 <div class="a-popover-preload" id="a-popover-readMorePreload">
                   <div class="a-row">
-                    <div class="a-column a-span6 a-text-right"><span class="a-size-base-plus a-color-base">Don't have Kindle for PC/Mac?</span></div>
-                    <div class="a-column a-span6 a-text-left a-span-last"><a class="a-size-base-plus a-link-normal a-text-normal" href="https://www.amazon.com/gp/kindle/kcpApp.html">Download it now for free</a></div>
-                    <div class="a-column a-span12 a-text-center a-spacing-top-base"><span class="a-declarative" data-action="a-popover-close" data-a-popover-close="{}"><a class="a-size-base-plus a-link-normal a-text-normal">Close</a></span></div>
+                    <div class="a-column a-span6 a-text-right"><span class="a-size-base-plus a-color-base"></span></div>
+                    <div class="a-column a-span6 a-text-left a-span-last"><a class="a-size-base-plus a-link-normal a-text-normal" href="https://www.amazon.com/gp/kindle/kcpApp.html"></a></div>
+                    <div class="a-column a-span12 a-text-center a-spacing-top-base"><span class="a-declarative" data-action="a-popover-close" data-a-popover-close="{}"><a class="a-size-base-plus a-link-normal a-text-normal">閉じる</a></span></div>
                   </div>
                 </div>
                 <div id="editNoteDiv" class="a-row a-spacing-top-large aok-hidden">
-                  <label for="editNoteTextArea" class="kp-notebook-modal-label">Write your note here...</label>
+                  <label for="editNoteTextArea" class="kp-notebook-modal-label">ここにメモを入力してください...</label>
                   <div class="a-input-text-wrapper a-span12">
                     <textarea id="editNoteTextArea"></textarea>
                   </div>
@@ -486,21 +517,21 @@
                     <div class="a-box a-alert-inline a-alert-inline-error">
                       <div class="a-box-inner a-alert-container">
                         <i class="a-icon a-icon-alert"></i>
-                        <div class="a-alert-content">Sorry, we''ve experienced a problem. Please try again.</div>
+                        <div class="a-alert-content">申し訳ありませんが、問題が発生しました。もう一度お試しください。</div>
                       </div>
                     </div>
                   </div>
                   <div class="a-row a-spacing-top-small">
                     <div class="a-column a-span8 a-text-right a-span-last">
                       <ul class="a-unordered-list a-nostyle a-horizontal">
-                        <li><span class="a-list-item"><span class="a-declarative" data-action="cancel-edit-note-action" data-cancel-edit-note-action="{}"><span id="cancelEditText" class="a-button"><span class="a-button-inner"><input class="a-button-input" type="submit"><span id="cancelEditText-announce" class="a-button-text">Cancel</span></span></span></span></span></li>
-                        <li><span class="a-list-item"><span class="a-declarative" data-action="edit-note-action" data-edit-note-action="{}"><span id="editNoteText" class="a-button a-button-primary"><span class="a-button-inner"><input class="a-button-input" type="submit"><span id="editNoteText-announce" class="a-button-text">Save</span></span></span></span></span></li>
+                        <li><span class="a-list-item"><span class="a-declarative" data-action="cancel-edit-note-action" data-cancel-edit-note-action="{}"><span id="cancelEditText" class="a-button"><span class="a-button-inner"><input class="a-button-input" type="submit"><span id="cancelEditText-announce" class="a-button-text">キャンセル</span></span></span></span></span></li>
+                        <li><span class="a-list-item"><span class="a-declarative" data-action="edit-note-action" data-edit-note-action="{}"><span id="editNoteText" class="a-button a-button-primary"><span class="a-button-inner"><input class="a-button-input" type="submit"><span id="editNoteText-announce" class="a-button-text">OK</span></span></span></span></span></li>
                       </ul>
                     </div>
                   </div>
                 </div>
                 <div id="addNoteDiv" class="a-row a-spacing-top-large aok-hidden">
-                  <label for="addNoteTextArea" class="kp-notebook-modal-label">Write your note here...</label>
+                  <label for="addNoteTextArea" class="kp-notebook-modal-label">ここにメモを入力してください...</label>
                   <div class="a-input-text-wrapper a-span12">
                     <textarea id="addNoteTextArea"></textarea>
                   </div>
@@ -509,15 +540,15 @@
                     <div class="a-box a-alert-inline a-alert-inline-error">
                       <div class="a-box-inner a-alert-container">
                         <i class="a-icon a-icon-alert"></i>
-                        <div class="a-alert-content">Sorry, we''ve experienced a problem. Please try again.</div>
+                        <div class="a-alert-content">申し訳ありませんが、問題が発生しました。もう一度お試しください。</div>
                       </div>
                     </div>
                   </div>
                   <div class="a-row a-spacing-top-small">
                     <div class="a-column a-span8 a-text-right a-span-last">
                       <ul class="a-unordered-list a-nostyle a-horizontal">
-                        <li><span class="a-list-item"><span class="a-declarative" data-action="cancel-add-note-action" data-cancel-add-note-action="{}"><span id="cancelAddNoteText" class="a-button"><span class="a-button-inner"><input class="a-button-input" type="submit"><span id="cancelAddNoteText-announce" class="a-button-text">Cancel</span></span></span></span></span></li>
-                        <li><span class="a-list-item"><span class="a-declarative" data-action="add-note-action" data-add-note-action="{}"><span id="addNoteText" class="a-button a-button-primary"><span class="a-button-inner"><input class="a-button-input" type="submit"><span id="addNoteText-announce" class="a-button-text">Save</span></span></span></span></span></li>
+                        <li><span class="a-list-item"><span class="a-declarative" data-action="cancel-add-note-action" data-cancel-add-note-action="{}"><span id="cancelAddNoteText" class="a-button"><span class="a-button-inner"><input class="a-button-input" type="submit"><span id="cancelAddNoteText-announce" class="a-button-text">キャンセル</span></span></span></span></span></li>
+                        <li><span class="a-list-item"><span class="a-declarative" data-action="add-note-action" data-add-note-action="{}"><span id="addNoteText" class="a-button a-button-primary"><span class="a-button-inner"><input class="a-button-input" type="submit"><span id="addNoteText-announce" class="a-button-text">OK</span></span></span></span></span></li>
                       </ul>
                     </div>
                   </div>

--- a/spec/kindle_manager/client_spec.rb
+++ b/spec/kindle_manager/client_spec.rb
@@ -9,9 +9,12 @@ describe KindleManager::Client do
     it "lists books" do
       client = KindleManager::Client.new
       books = client.load_kindle_books
-      expect(books.first.asin).to be_present
       expect(books.size).to be > 0
+      expect(books.first.asin).to be_present
       expect(books.map(&:asin).uniq.size).to eql(books.uniq.size)
+      expect{
+        books.map(&:to_hash)
+      }.not_to raise_error
     end
   end
 
@@ -23,10 +26,13 @@ describe KindleManager::Client do
     it "lists highlights" do
       client = KindleManager::Client.new
       books = client.load_kindle_highlights
-      expect(books.first.asin).to be_present
       expect(books.size).to be > 0
+      expect(books.first.asin).to be_present
       expect(books.map(&:asin).uniq.size).to eql(books.uniq.size)
       expect(books.none?(&:invalid?)).to be_truthy
+      expect{
+        books.map(&:to_hash)
+      }.not_to raise_error
     end
   end
 end

--- a/spec/kindle_manager/parsers/highlights_parser_spec.rb
+++ b/spec/kindle_manager/parsers/highlights_parser_spec.rb
@@ -48,7 +48,7 @@ describe KindleManager::HighlightsParser do
     describe '#invalid?' do
       it "verifies count of nodes and count_summary part" do
         book = @parser.parse.last
-        expect(book.count_summary['text']).to match(/\d+.*Highlight.*\d.*Note/m)
+        expect(book.count_summary['text']).to match(/\d+.*|.*\d.*/m)
         expect(book.count_summary['highlights_count']).to eql(8)
         expect(book.count_summary['notes_count']).to eql(7)
         expect(book.invalid?).to be_falsey


### PR DESCRIPTION
    The html in spec/fixtures/files is sanitized and beautified.

    In rails console or console which can require Loofah,
      load your file and convert it.
    > puts Loofah.scrub_document(html, :prune).to_s.split("\n").reject(&:blank?).join("\n")

    $ htmlbeautifier < input > output
    https://github.com/threedaymonk/htmlbeautifier