### PR TITLE
Fix error on parsing Japanese date

### DIFF
--- a/lib/kindle_manager/parsers/common.rb
+++ b/lib/kindle_manager/parsers/common.rb
@@ -11,8 +11,9 @@ module KindleManager
         begin
           Date.parse(date_text)
         rescue ArgumentError => e
-          m = date_text.match(/\A(?<year>\d{4})年(?<month>\d{1,2})月(?<day>\d{1,2})日\z/)
+          m = date_text.match(/\A(?<year>\d{4})年(?<month>\d{1,2})月(?<day>\d{1,2})日/)
           m = date_text.match(/(?<month>\d{1,2})月\D+(?<day>\d{1,2}),\D+(?<year>\d{4})/) if m.nil?
+          raise("Failed to parse date [#{date_text}]") if m.nil?
           Date.new(m[:year].to_i, m[:month].to_i, m[:day].to_i)
         end
       end


### PR DESCRIPTION
Day of week may be newly added.
RuntimeError: Failed to parse date [2017年8月9日 水曜日]