### PR TITLE
Fix error when highlight has empty content

### DIFF
--- a/lib/kindle_manager/parsers/highlights_parser.rb
+++ b/lib/kindle_manager/parsers/highlights_parser.rb
@@ -40,13 +40,18 @@ module KindleManager
         @_highlights_and_notes ||= begin
           # Excluding the first element which has book info
           @node.css('.a-spacing-base')[1..-1].map do |node|
-            location = node.css('#kp-annotation-location').first['value'].to_i
-            highlight_node = node.css('.kp-notebook-highlight').first
-            highlight = highlight_node && highlight_node.css('#highlight').first.text
-            color = highlight_node && highlight_node['class'].split.find{|v| v =~ /kp-notebook-highlight-/ }.split('-').last
-            note = node.css('#note').first.text
-            {'location' => location, 'highlight' => highlight, 'color' => color, 'note' => note}
-          end
+            begin
+              location = node.css('#kp-annotation-location').first['value'].to_i
+              highlight_node = node.css('.kp-notebook-highlight').first
+              highlight = highlight_node && highlight_node.css('#highlight').first.text
+              color = highlight_node && highlight_node['class'].split.find{|v| v =~ /kp-notebook-highlight-/ }.split('-').last
+              note = node.css('#note').first.text
+              {'location' => location, 'highlight' => highlight, 'color' => color, 'note' => note}
+            rescue => e
+              puts "[DEBUG] #{e.class}: #{e.message}\n#{node.to_html}\n"
+              next
+            end
+          end.compact
         end
       end
 


### PR DESCRIPTION
Example of html

```
<div id="highlight-QUpMRzRRWFVSTDk5NjpCMDdMRzdURzVOOjE4NDE1OkhJR0hMSUdIVDphMkFLS1lLM1Y5MVM2VQ" class="a-row kp-notebook-highlight kp-notebook-selectable kp-notebook-highlight-blue">
  <div class="a-box a-alert-inline a-alert-inline-warning kp-notebook-highlight-empty-text">
    <div class="a-box-inner a-alert-container">
      <i class="a-icon a-icon-alert"></i>
      <div class="a-alert-content">Sorry, we’re unable to display this type of content.</div>
    </div>
  </div>
  <div></div>
</div>
```
